### PR TITLE
Fix #12

### DIFF
--- a/Common/Delay.c
+++ b/Common/Delay.c
@@ -100,7 +100,7 @@ void Timer3_Delay100ms(UINT32 u32CNT)
 //------------------------------------------------------------------------------
 void Timer3_Delay10us(UINT32 u32CNT)
 {
-    T3CON = 0x07;                           		//Timer3 Clock = Fsys/128
+    T3CON = 0x02;                           		//Timer3 Clock = Fsys/4
     set_TR3;                                		//Trigger Timer3
     while (u32CNT != 0)
     {


### PR DESCRIPTION
- Function Timer3_Delay10us is not working correctly

T3CON must be Fsys/4 cause L107/L108 using TIMER_DIV4_VALUE_10us